### PR TITLE
Return correct date for each payment from getMortgagePayoff()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -226,7 +226,7 @@ export const getMortgagePayoff = (
    * Payoff grid
    */
   for (let i = 0; i < loanLength; i++) {
-    const dateRow = date;
+    const dateRow = new Date(date);
     const interestRow = getSimpleInterest(remainingLoan, interestRate);
     const principal = mountlyPayment - interestRow;
     const principalExtra = principal + extraPrincipal;


### PR DESCRIPTION
Due to setting the value of dateRow by reference it was previously the same value for all items, by creating a copy of the date in each iteration it now returns the correct date.

## Previous response

Note that the date is `2050-10-16T17:12:13.840Z` in all the items.

```js
{
	startDate: "2020-10-16T17:12:13.840Z",
	endDate: "2050-09-16T17:12:13.840Z",
	data: [{
			date: "2050-10-16T17:12:13.840Z",
			interest: 1250,
			principal: 148.42901710555498,
			principalExtra: 148.42901710555498,
			balance: 199851.57098289445
		},
		{
			date: "2050-10-16T17:12:13.840Z",
			interest: 1249.0723186430903,
			principal: 149.3566984624647,
			principalExtra: 149.3566984624647,
			balance: 199702.21428443198
		},
		{
			date: "2050-10-16T17:12:13.840Z",
			interest: 1248.1388392776998,
			principal: 150.29017782785513,
			principalExtra: 150.29017782785513,
			balance: 199551.92410660413
		}
	]
}
```